### PR TITLE
chore: update flutter_hooks

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   connectivity_plus: ^6.1.3
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
-  flutter_hooks: '>=0.18.2 <0.21.0'
+  flutter_hooks: '>=0.18.2 <0.22.0'
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
This pull request updates the version constraint for the `flutter_hooks` dependency in the `packages/graphql_flutter/pubspec.yaml` file to allow compatibility with versions up to `<0.22.0`.